### PR TITLE
Support for REPL-simulated test cases

### DIFF
--- a/test/sample_bad.md_
+++ b/test/sample_bad.md_
@@ -12,6 +12,15 @@ This test should raise an exception:
 
     sqrt(-1)    #-> 0.0 + 1.0im
 
-Finally, the last test is ill-formed:
+This one is ill-formed:
 
     #-> test code is missing
+
+Another test which should fail:
+
+    julia> 42
+    43
+
+And yet another ill-formed:
+
+    julia>

--- a/test/sample_good.md_
+++ b/test/sample_good.md_
@@ -11,3 +11,8 @@ We could also check if some code produces expected output:
 We could use ellipsis to match a sequence of characters:
 
     collect(1:10)   #-> [1, 2, …, 10]
+
+We could use specify tests using syntax simulating REPL session:
+
+    julia> (3+4)*6
+    42


### PR DESCRIPTION
The implementation is based on the code from Documenter.jl.

Allows to define test cases with REPL-simulated syntax:

    julia> 1
    1

This is useful as allows to define new test cases by simply copy pasting real REPL sessions.

If you think this is useful I can improve the test suite (now the test execution isn't tested and it should be as code path is altered to use same output display as in REPL). Otherwise I'm fine with vendoring NarrativeTest.jl in my code directly if you think the package should stay as-is.